### PR TITLE
Add an alternative source for treeclustering

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,19 @@ See here: https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105
 
 The code was stored on google code, you can see the archive here: http://code.google.com/p/pyms/
 
-The upstream repository here on github from @ma-bio21 seems more up to date than the code found in the archive, 
-most notably the implementation of using mpi4py in loading ANDI files. There are other differences though, 
-some bug fixes and added functionality. 
+The upstream repository here on github from @ma-bio21 which I assume is related to the origin
+of the code (the bio 21 institute in Melbourne) seems more up to date than the code found in the archive, 
+most notably the implementation of using mpi4py in ANDI file batches. There are other differences though, 
+some bug fixes and added functionality.
 
 A note: in the setup.py there is a requirement for the Pycluster library and it is used in the 
 files found in the ./Peak/List/DPA directory, but installing the library from pip failed on my machine 
-(Linux Mint 18 Sarah with python 2.7.12 installed).
+(Linux Mint 18 Sarah with python 2.7.12 installed). Another package, biopython, contains a treeclustering
+function that seems to be identical in terms of function, see e.g. the test package shown here:
+http://nullege.com/codes/search/Bio.Cluster.treecluster.
+I adapted the same approach where Pycluster was invoked since biopython installed without problem but 
+can't test it since the data refenced in the manual is not available any more.
+
 
 A diff of the two directories (from git and from google code) list the following files as different:
 - ./Deconvolution/BillerBiemann/Function.py 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ The upstream repository here on github from @ma-bio21 seems more up to date than
 most notably the implementation of using mpi4py in loading ANDI files. There are other differences though, 
 some bug fixes and added functionality. 
 
-Also a note: in the setup.py there is a requirement for the Pycluster library and it is used in the 
+A note: in the setup.py there is a requirement for the Pycluster library and it is used in the 
 files found in the ./Peak/List/DPA directory, but installing the library from pip failed on my machine 
 (Linux Mint 18 Sarah with python 2.7.12 installed).
 
-A diff of the two directories list the following files as different:
+A diff of the two directories (from git and from google code) list the following files as different:
 - ./Deconvolution/BillerBiemann/Function.py 
 - ./Display/Class.py 
 - ./Display/Class.pyc 

--- a/README.md
+++ b/README.md
@@ -4,25 +4,25 @@ See here: https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105
 
 The code was stored on google code, you can see the archive here: http://code.google.com/p/pyms/
 
-The upstream repository here on github from ma-bio21 seems more up to date than the code found in the archive, 
+The upstream repository here on github from @ma-bio21 seems more up to date than the code found in the archive, 
 most notably the implementation of using mpi4py in loading ANDI files. There are other differences though, 
 some bug fixes and added functionality. 
 
 A diff of the two directories list the following files as different:
-./Deconvolution/BillerBiemann/Function.py 
-./Display/Class.py 
-./Display/Class.pyc 
-./Experiment/IO.py 
-./Gapfill/Class.py 
-./Gapfill/Function.py 
-./Gapfill/__init__.py 
-./GCMS/Class.py 
-./GCMS/IO/ANDI/Function.py 
-./GCMS/IO/MZML/Function.py 
-./GCMS/IO/MZML/__init__.py 
-./Peak/Class.py 
-./Peak/List/DPA/Class_old.py 
-./Peak/List/DPA/Class.py 
-./Peak/List/DPA/Function_new.py 
-./Peak/List/DPA/Function.py 
-./Utils/DP.py 
+- ./Deconvolution/BillerBiemann/Function.py 
+- ./Display/Class.py 
+- ./Display/Class.pyc 
+- ./Experiment/IO.py 
+- ./Gapfill/Class.py 
+- ./Gapfill/Function.py 
+- ./Gapfill/__init__.py 
+- ./GCMS/Class.py 
+- ./GCMS/IO/ANDI/Function.py 
+- ./GCMS/IO/MZML/Function.py 
+- ./GCMS/IO/MZML/__init__.py 
+- ./Peak/Class.py 
+- ./Peak/List/DPA/Class_old.py 
+- ./Peak/List/DPA/Class.py 
+- ./Peak/List/DPA/Function_new.py 
+- ./Peak/List/DPA/Function.py 
+- ./Utils/DP.py 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ The upstream repository here on github from @ma-bio21 seems more up to date than
 most notably the implementation of using mpi4py in loading ANDI files. There are other differences though, 
 some bug fixes and added functionality. 
 
+Also a note: in the setup.py there is a requirement for the Pycluster library and it is used in the 
+files found in the ./Peak/List/DPA directory, but installing the library from pip failed on my machine 
+(Linux Mint 18 Sarah with python 2.7.12 installed).
+
 A diff of the two directories list the following files as different:
 - ./Deconvolution/BillerBiemann/Function.py 
 - ./Display/Class.py 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# pyms
+The original source is a python package called pyms that was developed and published in 2012.
+See here: https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-13-115
+
+The code was stored on google code, you can see the archive here: http://code.google.com/p/pyms/
+
+The upstream repository here on github from ma-bio21 seems more up to date than the code found in the archive, 
+most notably the implementation of using mpi4py in loading ANDI files. There are other differences though, 
+some bug fixes and added functionality. 
+
+A diff of the two directories list the following files as different:
+./Deconvolution/BillerBiemann/Function.py 
+./Display/Class.py 
+./Display/Class.pyc 
+./Experiment/IO.py 
+./Gapfill/Class.py 
+./Gapfill/Function.py 
+./Gapfill/__init__.py 
+./GCMS/Class.py 
+./GCMS/IO/ANDI/Function.py 
+./GCMS/IO/MZML/Function.py 
+./GCMS/IO/MZML/__init__.py 
+./Peak/Class.py 
+./Peak/List/DPA/Class_old.py 
+./Peak/List/DPA/Class.py 
+./Peak/List/DPA/Function_new.py 
+./Peak/List/DPA/Function.py 
+./Utils/DP.py 

--- a/pyms/Peak/List/DPA/Class.py
+++ b/pyms/Peak/List/DPA/Class.py
@@ -24,7 +24,11 @@ Classes for peak alignment by dynamic programming
 
 import copy
 
-import numpy, Pycluster
+import numpy
+try:
+    from Pycluster import treecluster
+except:
+    from Bio.Cluster import treecluster
 
 from pyms.Utils.Error import error, stop
 from pyms.Utils.IO import dump_object
@@ -741,7 +745,7 @@ class PairwiseAlignment(object):
         n = len(dist_matrix)
 
         print " -> Clustering %d pairwise alignments." % (n*(n-1)),
-        tree = Pycluster.treecluster(distancematrix=dist_matrix, method='a')
+        tree = treecluster(distancematrix=dist_matrix, method='a')
         print "Done"
 
         return tree

--- a/pyms/Peak/List/DPA/Class_old.py
+++ b/pyms/Peak/List/DPA/Class_old.py
@@ -24,7 +24,11 @@ Classes for peak alignment by dynamic programming
 
 import copy
 
-import numpy, Pycluster
+import numpy
+try:
+    from Pycluster import treecluster
+except:
+    from Bio.Cluster import treecluster
 
 from pyms.Utils.Error import error, stop
 from pyms.Experiment.Class import Experiment
@@ -548,7 +552,7 @@ class PairwiseAlignment(object):
         n = len(dist_matrix)
 
         print " -> Clustering %d pairwise alignments." % (n*(n-1)),
-        tree = Pycluster.treecluster(distancematrix=dist_matrix, method='a')
+        tree = treecluster(distancematrix=dist_matrix, method='a')
         print "Done"
 
         return tree


### PR DESCRIPTION
On my machine I could not get pip to install the required source for treeclustering. I found another source, biopython, that has a module of the same name and in their tests cases they test both modules. I can't test the functionality in pyMS since I a missing the data files from the documentation but I assume it is the same. Maybe this will help someone else.